### PR TITLE
Прилагательное вместо глагола CLEAN_NAME и DISPLAY_NAME

### DIFF
--- a/language/ru/acp/extensions.php
+++ b/language/ru/acp/extensions.php
@@ -89,8 +89,8 @@ $lang = array_merge($lang, array(
 	'RETURN_TO_EXTENSION_LIST'	=> 'Вернуться к списку расширений',
 
 	'EXT_DETAILS'			=> 'Информация о расширении',
-	'DISPLAY_NAME'			=> 'Показать имя',
-	'CLEAN_NAME'			=> 'Очистить имя',
+	'DISPLAY_NAME'			=> 'Отображаемое имя',
+	'CLEAN_NAME'			=> 'Чистое имя',
 	'TYPE'					=> 'Тип',
 	'DESCRIPTION'			=> 'Описание',
 	'VERSION'				=> 'Версия',

--- a/language/ru/acp/extensions.php
+++ b/language/ru/acp/extensions.php
@@ -90,7 +90,7 @@ $lang = array_merge($lang, array(
 
 	'EXT_DETAILS'			=> 'Информация о расширении',
 	'DISPLAY_NAME'			=> 'Отображаемое имя',
-	'CLEAN_NAME'			=> 'Чистое имя',
+	'CLEAN_NAME'			=> 'Имя на сервере',
 	'TYPE'					=> 'Тип',
 	'DESCRIPTION'			=> 'Описание',
 	'VERSION'				=> 'Версия',


### PR DESCRIPTION
Фразы "Clean Name" и "Display Name" используются как названия, а не описания действий.
![names_fix](https://cloud.githubusercontent.com/assets/7805635/3597916/0a370ab0-0cda-11e4-899b-60fa84b69c1e.png)
